### PR TITLE
Add ZENTRA Cloud dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+venv/
+.env
+__pycache__/

--- a/app.py
+++ b/app.py
@@ -1,7 +1,61 @@
-import requests
 import os
-from flask import Flask, render_template, jsonify
+from datetime import datetime, timedelta
+
+import requests
+from flask import Flask, render_template, jsonify, request
 from dotenv import load_dotenv
 
 load_dotenv()
 
+app = Flask(__name__, template_folder='.')
+
+API_TOKEN = os.environ.get('ZENTRA_API_TOKEN')
+DEVICE_ID = os.environ.get('ZENTRA_DEVICE_ID')
+
+
+def fetch_sensor_data(device_id=DEVICE_ID, token=API_TOKEN, hours=24):
+    """Fetch sensor data from ZENTRA Cloud.
+
+    If the API cannot be reached or credentials are missing, sample data
+    is generated for demonstration purposes.
+    """
+    start_time = datetime.utcnow() - timedelta(hours=hours)
+
+    if not device_id or not token or token.startswith('your_actual'):
+        # Return mock data when credentials are not configured
+        now = datetime.utcnow()
+        return [
+            {
+                "timestamp": (now - timedelta(hours=i)).isoformat() + "Z",
+                "value": 20 + i * 0.5,
+            }
+            for i in reversed(range(hours))
+        ]
+
+    url = f"https://api.zentracloud.com/v3/devices/{device_id}/measurements"
+    headers = {"Authorization": f"Bearer {token}"}
+    params = {"start": start_time.isoformat() + "Z"}
+    try:
+        resp = requests.get(url, headers=headers, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("measurements", [])
+    except Exception as exc:
+        print(f"Error fetching data from ZENTRA Cloud: {exc}")
+        return []
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/api/data")
+def api_data():
+    hours = int(request.args.get("hours", 24))
+    data = fetch_sensor_data(hours=hours)
+    return jsonify(data)
+
+
+if __name__ == "__main__":
+    app.run(debug=True, host="0.0.0.0")

--- a/index.html
+++ b/index.html
@@ -1,1 +1,13 @@
-hi
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>ZENTRA Sensor Dashboard</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+    <h1>ZENTRA Sensor Dashboard</h1>
+    <canvas id="sensorChart"></canvas>
+    <script src="static/main.js"></script>
+</body>
+</html>

--- a/static/main.js
+++ b/static/main.js
@@ -1,0 +1,46 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const ctx = document.getElementById('sensorChart').getContext('2d');
+    let chart;
+
+    async function loadData() {
+        const resp = await fetch('/api/data');
+        const data = await resp.json();
+        const labels = data.map(d => new Date(d.timestamp).toLocaleString());
+        const values = data.map(d => d.value);
+
+        if (chart) {
+            chart.data.labels = labels;
+            chart.data.datasets[0].data = values;
+            chart.update();
+        } else {
+            chart = new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: labels,
+                    datasets: [{
+                        label: 'Sensor Value',
+                        data: values,
+                        borderColor: 'rgba(75, 192, 192, 1)',
+                        backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                        tension: 0.1
+                    }]
+                },
+                options: {
+                    scales: {
+                        x: {
+                            display: true,
+                            title: { display: true, text: 'Time' }
+                        },
+                        y: {
+                            display: true,
+                            title: { display: true, text: 'Value' }
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    loadData();
+    setInterval(loadData, 60000);
+});


### PR DESCRIPTION
## Summary
- add `.gitignore`
- create chart-based dashboard in `index.html`
- fetch ZENTRA Cloud data with a fallback in `app.py`
- add frontend JavaScript for live updates

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6845dd70439483339cd74d2db55b4b0b